### PR TITLE
Updates to Board Notice and Volunteer Training

### DIFF
--- a/board-procedures/trainings.tex
+++ b/board-procedures/trainings.tex
@@ -30,23 +30,23 @@ position.
 		\centering
 		\begin{tabular}{|p{0.3\linewidth}|p{0.22\linewidth}|p{0.21\linewidth}|p{0.20\linewidth}|p{0.19\linewidth}|}
 			\hline
-			Groups                                                                                        & Employee Safety Orientation (SO1001) & Workplace Violence (SO1081) & Accessibility Training & Cyber Awareness Essentials \\
+			Groups                                                                                        & Employee Safety Orientation (SO1001) & Workplace Violence (SO1081) & Accessibility Training & Cyber Awareness Essentials & Sexual Violence Foundations \\
 			\hline
-			\textbf{A}: The Executive Officers of the Society, the Chair of the Society, and the Speaker. & \checkmark                           & \checkmark                  & \checkmark             & \checkmark                 \\
+			\textbf{A}: The Executive Officers of the Society, the Chair of the Society, and the Speaker. & \checkmark                           & \checkmark                  & \checkmark             & \checkmark                 & \checkmark                  \\
 			\hline
-			\textbf{B}: The Secretary of the Society and Council Secretary.                               &                                      & \checkmark                  &                        & \checkmark                 \\
+			\textbf{B}: The Secretary of the Society and Council Secretary.                               &                                      & \checkmark                  &                        & \checkmark                 & \checkmark                  \\
 			\hline
-			\textbf{C}: The president and other executives of Clubs under the aegis of MathSoc.           & \checkmark                           & \checkmark                  & \checkmark             & \checkmark                 \\
+			\textbf{C}: The president and other executives of Clubs under the aegis of MathSoc.           & \checkmark                           & \checkmark                  & \checkmark             & \checkmark                 & \checkmark                  \\
 			\hline
-			\textbf{D}: Event Volunteers under the Vice-President, Internal                               & \checkmark                           & \checkmark                  & \checkmark             & \checkmark                 \\
+			\textbf{D}: Event Volunteers under the Vice-President, Internal                               & \checkmark                           & \checkmark                  & \checkmark             & \checkmark                 & \checkmark                  \\
 			\hline
-			\textbf{E}: Office Managers under the Vice-President, Operations.                             & \checkmark                           & \checkmark                  & \checkmark             &                            \\
+			\textbf{E}: Office Managers under the Vice-President, Operations.                             & \checkmark                           & \checkmark                  & \checkmark             &                            & \checkmark                  \\
 			\hline
-			\textbf{F}: Office Staff under the Vice-President, Operations.                                &                                      & \checkmark                  & \checkmark             &                            \\
+			\textbf{F}: Office Staff under the Vice-President, Operations.                                &                                      & \checkmark                  & \checkmark             &                            & \checkmark                  \\
 			\hline
-			\textbf{G}: Finance Directors under the Vice-President, Finance.                              &                                      & \checkmark                  &                        & \checkmark                 \\
-			\hline
-			\textbf{H}: Academic Event Volunteers under the Vice-President, Academic.                     &                                      & \checkmark                  & \checkmark             &                            \\
+			\textbf{G}: Finance Directors under the Vice-President, Finance.                              &                                      & \checkmark                  &                        & \checkmark                 & \checkmark                  \\
+			\hline& \checkmark                 
+			\textbf{H}: Academic Event Volunteers under the Vice-President, Academic.                     &                                      & \checkmark                  & \checkmark             &                            & \checkmark                  \\
 			\hline
 		\end{tabular}
 	}

--- a/bylaws/content/board.tex
+++ b/bylaws/content/board.tex
@@ -153,14 +153,14 @@ Meetings of the Board of Directors may be called by any of the following;
     \textbf{Tristan Potter, Spring 2018}
 \end{annotation}
     
-Notice must be provided at least five (5) business days in advance of any
-meeting to every member of the Board of Directors unless that member explicitly
-waives their right to notice before the start of the meeting.
+Notice of the meeting and location must be provided at least five (5) business 
+days in advance of any meeting to every member of the Board of Directors unless 
+that member explicitly waives their right to notice before the start of the meeting.
 
-A full description of the intended motion, such as the text of a
-proposed amendment or agreement, must be provided, but the motion may be
-amended before or after it is moved as long as the changes remain within the
-scope of the motion for which notice was given.
+The full agenda, including a full description of the intended motions, such as 
+the text of proposed amendments or agreements, must be provided, no less than 
+72 hours before the meeting, but motions may be amended before or after they are 
+moved as long as the changes remain within the scope of the motion for which notice was given.
 
 The Board of Directors may designate a mailing list or similar forum to be the
 official notice forum of the Board of Directors; if this is done, then any


### PR DESCRIPTION
Updated as per F25 Nov 4, 2025 Board Meeting.
Live Agenda: https://docs.google.com/document/d/1RTjjq0JMbKl3f_0ruODGVBfiPToeGg3qEjmaZOllSkQ/edit?tab=t.0
Minutes: https://docs.google.com/document/d/1jSU3kAJQSe1HBbH1lcaOiRWoAwgDRRzGQjrgdwfgAXM/edit?tab=t.0

- Adds Sexual Violence Prevention Training as mandatory training for all positions
- Updates notice requirements for Board